### PR TITLE
Default to using i32 for records

### DIFF
--- a/benchmark_joins/src/field.rs
+++ b/benchmark_joins/src/field.rs
@@ -1,2 +1,0 @@
-// TODO make a field type so don't sprinkle specification
-// of Ts so we consolidate in one place

--- a/benchmark_joins/src/main.rs
+++ b/benchmark_joins/src/main.rs
@@ -17,8 +17,8 @@ fn main() {
 	let table1_name: &str = "tables/small1.csv";
 	let table2_name: &str = "tables/small2.csv";
 
-	let mut table1: SimpleTable<i32> = SimpleTable::new(table1_name);
-	let mut table2: SimpleTable<i32> = SimpleTable::new(table2_name);
+	let mut table1: SimpleTable = SimpleTable::new(table1_name);
+	let mut table2: SimpleTable = SimpleTable::new(table2_name);
 
 	// let mut join_algo: NestedLoopsJoin<i32> = NestedLoopsJoin::new(&mut table1, &mut table2);
 // 	for r in join_algo.equi_join(2, 0).iter() {

--- a/benchmark_joins/src/readtable.rs
+++ b/benchmark_joins/src/readtable.rs
@@ -1,32 +1,10 @@
 use std::error::Error;
 use std::fs::File;
-// use serde::Deserialize;
-use std::str::FromStr;
 use csv::StringRecord;
-use core::fmt::Debug;
 
-// #[derive(Debug, Deserialize)]
-// struct DummyTuple {
-//     col1: i16,
-//     col2: i16,
-//     col3: i16,
-// }
-
-// pub fn example(file_path: &str) -> Result<(), Box<dyn Error>> {
-//   let file = File::open(file_path)?;
-//   let mut rdr = csv::Reader::from_reader(file);
-//   for result in rdr.deserialize() {
-//       // Notice that we need to provide a type hint for automatic
-//       // deserialization.
-//       let record: DummyTuple = result?;
-//       println!("{:?}", record);
-//   }
-//   Ok(())
-// }
-
-pub fn fetch_records<T>(file_path: &str) -> Result<Vec<Vec<T>>, Box<dyn Error>> where T: Clone + FromStr + Debug, <T as FromStr>::Err: Debug {
+pub fn fetch_records(file_path: &str) -> Result<Vec<Vec<i32>>, Box<dyn Error>> {
   // Table to hold results
-  let mut raw_table: Vec<Vec<T>> = Vec::new();
+  let mut raw_table: Vec<Vec<i32>> = Vec::new();
 
   // File contain on-disk table
   let file = File::open(file_path)?;
@@ -36,12 +14,12 @@ pub fn fetch_records<T>(file_path: &str) -> Result<Vec<Vec<T>>, Box<dyn Error>> 
 
   for result in rdr.records() {
       // Holder of slots for the record
-      let mut raw_record: Vec<T> = Vec::new();
+      let mut raw_record: Vec<i32> = Vec::new();
       
       // Parse individual record fields as Ts
       let string_record: StringRecord = result?;
       for string_field in string_record.iter() {
-        match string_field.parse::<T>() {
+        match string_field.parse::<i32>() {
           Ok(parsed_field) => {
             // Case: success ==> push to our record
             raw_record.push(parsed_field);

--- a/benchmark_joins/src/record.rs
+++ b/benchmark_joins/src/record.rs
@@ -1,36 +1,19 @@
 use std::clone::Clone;
 use std::fmt::Debug;
 
-// pub struct Record<T, const LENGTH: usize> {
-//   pub data:[T; LENGTH],
-
-// }
-
-// impl<T, const LENGTH: usize> Record<T, LENGTH> {
-//   //TODO: see how to construct, if it is ugly then 
-//   //      write a "new()" method or something
-//   pub fn get_column(&self, i: usize) -> &T {
-//     &self.data[i]
-//   }
-
-//   pub fn get_num_columns(&self) -> usize {
-//     LENGTH
-//   } 
-// }
-
 #[derive(Debug, Clone)]
-pub struct Record<T> {
-  fields: Vec<T>
+pub struct Record {
+  fields: Vec<i32>
 }
 
-impl<T> Record<T> where T: Clone + Debug {
-  pub fn new(input_record: &[T]) -> Record<T> {
+impl Record {
+  pub fn new(input_record: &[i32]) -> Record {
     Record {
       fields: input_record.to_vec()
     }
   }
 
-  pub fn merge(r1: &Record<T>, r2: &Record<T>) -> Record<T> {
+  pub fn merge(r1: &Record, r2: &Record) -> Record {
     // Combine the record fields
     let mut combined_fields = r1.fields.clone();
     let mut fields2 = r2.fields.clone();
@@ -40,7 +23,7 @@ impl<T> Record<T> where T: Clone + Debug {
     Record::new(combined_fields.as_slice())
   }
 
-  pub fn get_column(&self, i: usize) -> &T {
+  pub fn get_column(&self, i: usize) -> &i32 {
     &self.fields[i]
   }
 

--- a/benchmark_joins/src/table.rs
+++ b/benchmark_joins/src/table.rs
@@ -1,30 +1,32 @@
-use core::str::FromStr;
-use core::fmt::Debug;
-use std::clone::Clone;
-
 use crate::record::Record;
 use crate::readtable::fetch_records;
 
-pub struct SimpleTable<T> {
-  records: Vec<Record<T>>,
+pub struct SimpleTable {
+  records: Vec<Record>,
   index: usize,
 
 }
 
-impl<T> SimpleTable<T> where T: Clone + Debug + FromStr, <T as FromStr>::Err: Debug {
-  pub fn new(filepath: &str) -> SimpleTable<T> {
+impl SimpleTable {
+  pub fn new(filepath: &str) -> SimpleTable {
     // Make the object
-    let mut simple_table: SimpleTable<T> = SimpleTable {
+    let mut simple_table: SimpleTable = SimpleTable {
       records: Vec::new(),
       index: 0
     };
 
     // Get raw table contents from on-disk table
-    let raw_table: Vec<Vec<T>> = fetch_records::<T>(filepath).unwrap();
-
+    let raw_table: Vec<Vec<i32>>;
+    match fetch_records(filepath) {
+      Err(e) => panic!("{:?}", e),
+      Ok(fetched_raw_table) => {
+        raw_table = fetched_raw_table;
+      }
+    }
+    
     for raw_record in raw_table.iter() {
       // Add each raw record as proper record to the table
-      let record: Record<T> = Record::new(raw_record);
+      let record: Record = Record::new(raw_record);
       simple_table.records.push(record);
     }
 
@@ -35,7 +37,7 @@ impl<T> SimpleTable<T> where T: Clone + Debug + FromStr, <T as FromStr>::Err: De
     return self.records.len();
   }
 
-  pub fn read_next_record(&mut self) -> Record<T> {
+  pub fn read_next_record(&mut self) -> Record {
     let record = self.records[self.index].clone();
     self.index += 1;
     record.clone()


### PR DESCRIPTION
We're moving away from general `Field` types, favoring simplicity of using `i32`s as the default `Field`