### PR TITLE
Reimplement with max size, add more extensive tests

### DIFF
--- a/benchmark_joins/Cargo.lock
+++ b/benchmark_joins/Cargo.lock
@@ -5,6 +5,7 @@ name = "benchmark_joins"
 version = "0.1.0"
 dependencies = [
  "csv",
+ "rand",
  "serde",
  "serde_json",
  "strum",
@@ -30,6 +31,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +56,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -73,10 +91,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "libc"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+
+[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
@@ -94,6 +124,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -182,3 +252,9 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"

--- a/benchmark_joins/Cargo.toml
+++ b/benchmark_joins/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum = "0.20"
 strum_macros = "0.20"
+rand = "0.8.0"

--- a/benchmark_joins/src/record.rs
+++ b/benchmark_joins/src/record.rs
@@ -15,7 +15,7 @@ pub struct Record {
 
 	// The next index to insert 
 	// a new column value into
-	field_insert_idx: usize,
+	tail: usize,
 }
 
 impl Record {
@@ -23,7 +23,7 @@ impl Record {
 		// New empty record
 		let mut new_record: Record = Record {
 			fields: [0; M],
-			field_insert_idx: 0
+			tail: 0
 		};
 		
 		// Add each input column
@@ -38,7 +38,7 @@ impl Record {
 		// New record
 		let mut nr: Record = Record {
 			fields: [0; M],
-			field_insert_idx: 0
+			tail: 0
 		};
 
 		// Add first record
@@ -60,7 +60,7 @@ impl Record {
 			panic!("OOB Capacity");
 		}
 		// Index OOB
-		if i >= self.field_insert_idx {
+		if i >= self.tail {
 			panic!("OOB Index")
 		}
 
@@ -68,17 +68,17 @@ impl Record {
 	}
 
 	pub fn get_num_columns(&self) -> usize {
-		self.field_insert_idx
+		self.tail
 	}
 
 	fn add_column(&mut self, value: i32) -> () {
 		// Check capacity to insert
-		if (self.field_insert_idx as usize) >= M {
+		if (self.tail as usize) >= M {
 			panic!("Insufficient capacity for insert");
 		} 
 		// Insert column and move to next spot placeholder
-		self.fields[self.field_insert_idx] = value;
-		self.field_insert_idx += 1;
+		self.fields[self.tail] = value;
+		self.tail += 1;
 	}
 }
 

--- a/benchmark_joins/src/record.rs
+++ b/benchmark_joins/src/record.rs
@@ -1,68 +1,203 @@
 use std::clone::Clone;
 use std::cmp::Ordering;
 use std::fmt::Debug;
+use rand::{seq::SliceRandom, thread_rng};
+use std::panic;
+
+// Maximum fields in a record
+pub const M: usize = 100;
 
 #[derive(Debug, Clone)]
 pub struct Record {
-  fields: Vec<i32>
+	// Array of i32s whose capacity
+	// is preallocated to max of M
+	fields: [i32; M],
+
+	// The next index to insert 
+	// a new column value into
+	field_insert_idx: usize,
 }
 
-
 impl Record {
-  pub fn new(input_record: &[i32]) -> Record {
-    Record {
-      fields: input_record.to_vec()
-    }
-  }
+	pub fn new(input_record: &[i32]) -> Record {
+		// New empty record
+		let mut new_record: Record = Record {
+			fields: [0; M],
+			field_insert_idx: 0
+		};
+		
+		// Add each input column
+		for value_ptr in input_record.into_iter() {
+			new_record.add_column(*value_ptr);
+		}
 
-  pub fn merge(r1: &Record, r2: &Record) -> Record {
-    // Combine the record fields
-    let mut combined_fields = r1.fields.clone();
-    let mut fields2 = r2.fields.clone();
-    combined_fields.append(&mut fields2);
+		new_record
+	}
 
-    // New record from combined fields
-    Record::new(combined_fields.as_slice())
-  }
+	pub fn merge(r1: &Record, r2: &Record) -> Record {
+		// New record
+		let mut nr: Record = Record {
+			fields: [0; M],
+			field_insert_idx: 0
+		};
 
-  pub fn get_column(&self, i: usize) -> &i32 {
-    &self.fields[i]
-  }
+		// Add first record
+		for i in 0..r1.get_num_columns() {
+			nr.add_column(*r1.get_column(i));
+		}
 
-  pub fn get_num_columns(&self) -> usize {
-    self.fields.len()
-  } 
+		// Add second record
+		for i in 0..r2.get_num_columns() {
+			nr.add_column(*r2.get_column(i));
+		}
+
+		nr
+	}
+
+	pub fn get_column(&self, i: usize) -> &i32 {
+		// Capacity OOB
+		if i >= M {
+			panic!("OOB Capacity");
+		}
+		// Index OOB
+		if i >= self.field_insert_idx {
+			panic!("OOB Index")
+		}
+
+		&self.fields[i]
+	}
+
+	pub fn get_num_columns(&self) -> usize {
+		self.field_insert_idx
+	}
+
+	fn add_column(&mut self, value: i32) -> () {
+		// Check capacity to insert
+		if (self.field_insert_idx as usize) >= M {
+			panic!("Insufficient capacity for insert");
+		} 
+		// Insert column and move to next spot placeholder
+		self.fields[self.field_insert_idx] = value;
+		self.field_insert_idx += 1;
+	}
 }
 
 impl Ord for Record {
-  fn cmp(&self, other: &Self) -> Ordering {
-      self.fields.cmp(&other.fields)
-  }
+	fn cmp(&self, other: &Self) -> Ordering {
+			self.fields.cmp(&other.fields)
+	}
 }
 
 impl PartialOrd for Record {
-  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-      Some(self.fields.cmp(&other.fields))
-  }
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+			Some(self.fields.cmp(&other.fields))
+	}
 }
 
 impl PartialEq for Record {
-  fn eq(&self, other: &Self) -> bool {
-      self.fields == other.fields
-  }
+	fn eq(&self, other: &Self) -> bool {
+			self.fields == other.fields
+	}
 }
 
 impl Eq for Record {}
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-  
-  #[test]
-  fn test_record() {
-    let data = [1, 2, 3, 420];
-    let rec = Record::new(&data);
-    assert_eq!(420, *rec.get_column(3));
-    assert_eq!(4, rec.get_num_columns());
-  }
+	use super::*;
+
+	fn check_size(r: &Record, expected_size: usize) {
+		assert_eq!(expected_size, r.get_num_columns());
+	}
+
+	fn check_column(r: &Record, col_idx: usize, expected_value: i32) {
+		assert_eq!(expected_value, *r.get_column(col_idx));
+	}
+
+	fn check_columns_in_order(r: &Record, columns: &[i32]) {
+		for i in 0..columns.len() {
+			check_column(r, i, columns[i]);
+		}
+	}
+	
+	fn check_columns_randomly(r: &Record, columns: &[i32]) {
+		// Populate indexs
+		let mut indexes: Vec<usize> = (0..columns.len()).collect();
+
+		// Shuffle indexes
+		indexes.shuffle(&mut thread_rng());
+
+		// Check column values
+		for i in indexes {
+			check_column(r, i, columns[i])
+		}
+	}
+
+	fn check_column_oob(r: &Record) {
+		// try idx len, should panic
+		let result = panic::catch_unwind(|| r.get_column(r.get_num_columns()));
+		assert!(result.is_err());
+
+		// try idx len + 100, should panic
+		let result = panic::catch_unwind(|| r.get_column(100 + r.get_num_columns()));
+		assert!(result.is_err());
+	}
+
+	fn check_record(r: &Record, columns: &[i32]) {
+		// Check size
+		check_size(r, columns.len());
+
+		// Check column values
+		check_columns_in_order(r, columns);
+		check_columns_randomly(r, columns);
+
+		// Check OOB access
+		check_column_oob(r);
+	}
+
+	#[test]
+	fn test_empty_record() {
+		// Tiny
+		let columns = [];
+		let r = Record::new(&columns);
+		check_record(&r, &columns);
+	}
+
+	#[test]
+	fn test_small_record() {
+		// Smol
+		let columns = [98752, -23765];
+		let r = Record::new(&columns);
+		check_record(&r, &columns);
+	}
+
+	#[test]
+	fn test_medium_record() {
+		// Medium
+		let columns = [1, 2, 3, 4, 4, 4, 5, 6, 420];
+		let r = Record::new(&columns);
+		check_record(&r, &columns);
+	}
+
+	#[test]
+	fn test_large_record() {
+		// Thiqq
+		let mut columns: [i32; 75] = [0; 75];
+		for v in 1000..1075 {
+			columns[v - 1000] = v as i32;
+		}
+		let r = Record::new(&columns);
+		check_record(&r, &columns);
+	}
+
+	#[test]
+	fn test_max_record() {
+		// Huge
+		let mut columns: [i32; M] = [0; M];
+		for v in 6..(6+M) {
+			columns[v - 6] = v as i32;
+		}
+		let r = Record::new(&columns);
+		check_record(&r, &columns);
+	}
 }


### PR DESCRIPTION
* Reimplement `Record` with a max size of `M = 100`. We can always change this number as necessary
* Add more extensive tests to `Record` to verify correctness
* Convert indentation to tabs