### PR TITLE
Noclone

### DIFF
--- a/benchmark_joins/src/bin/generate/tablegenerator.rs
+++ b/benchmark_joins/src/bin/generate/tablegenerator.rs
@@ -102,7 +102,7 @@ pub fn generate_and_write_table(num_rows: usize, num_cols: usize, path: &str) ->
 fn get_table_column_values(table: &Vec<Record>, col: usize) -> HashSet<i32> {
 	let mut cols = HashSet::new();
 	for record in table {
-		let val = record.get_column(col);
+		let val = *record.get_column(col);
 		cols.insert(val);
 	}
 	cols
@@ -135,10 +135,10 @@ pub fn generate_right_table(left_table: Vec<Record>,
   // Fill in enough matching values in the right table join column
   // to achieve the desired level of selectivity
   for i in 0..rounded_matches {
-    let value: i32 = left_table.get(i).unwrap().get_column(left_col);
+    let value: i32 = *left_table.get(i).unwrap().get_column(left_col);
     let right_record: &mut Record = &mut right_table[i];
     right_record.set_column(right_col, value);
-		assert!(right_table.get(i).unwrap().get_column(right_col) == value);
+		assert!(*right_table.get(i).unwrap().get_column(right_col) == value);
   }
 
 	// Now fill in the remaing values from the missing value picker
@@ -148,7 +148,7 @@ pub fn generate_right_table(left_table: Vec<Record>,
     let value: i32 = mvp.next();
 		let right_record: &mut Record = &mut right_table[i];
     right_record.set_column(right_col, value);
-		assert!(right_table.get(i).unwrap().get_column(right_col) == value);
+		assert!(*right_table.get(i).unwrap().get_column(right_col) == value);
 	}
 
   // Rerandomize right table so join results are not just

--- a/benchmark_joins/src/join.rs
+++ b/benchmark_joins/src/join.rs
@@ -76,7 +76,7 @@ impl<'a> BlockNL<'a> {
     }
   }
 
-  fn get_effective_block_size(&self, num_records: usize, block_size: usize) -> usize {
+  fn get_effective_num_blocks(&self, num_records: usize, block_size: usize) -> usize {
     let intermidate: f64 = ((num_records as f64) / (block_size as f64)).ceil();
     intermidate as usize
   }
@@ -87,17 +87,17 @@ impl<'a> BlockNL<'a> {
     let right_size = self.right.get_num_records();
 
     // Number of effective blocks for left and right tables
-    let effective_l_block_sz = self.get_effective_block_size(left_size, self.l_block_sz);
-    let effective_r_block_sz = self.get_effective_block_size(right_size, self.r_block_sz);
+    let effective_left_num_blocks = self.get_effective_num_blocks(left_size, self.l_block_sz);
+    let effective_right_num_blocks = self.get_effective_num_blocks(right_size, self.r_block_sz);
 
     // Since this is a primary-key foreign-key equijoin
     // we know the the join will be no larger than left table
     let mut join_result = Vec::with_capacity(left_size);
 
-    for _l in 0..effective_l_block_sz  {
+    for _l in 0..effective_left_num_blocks  {
       let left_block = self.left.read_next_block(self.l_block_sz);
 
-      for _r in 0..effective_r_block_sz {
+      for _r in 0..effective_right_num_blocks {
         let right_block = self.right.read_next_block(self.r_block_sz);
 
         for left_record in left_block {

--- a/benchmark_joins/src/join.rs
+++ b/benchmark_joins/src/join.rs
@@ -29,27 +29,30 @@ impl<'a> NestedLoopsJoin<'a> {
   }
 
   pub fn equi_join(&mut self, left_col: usize, right_col: usize) -> Vec<Record> {
-    // TODO: Remove the duplicated concatenation
-    let mut join_result: Vec<Record> = Vec::new();
+    // Number of records in left and right tables
+    let left_size = self.left.get_num_records();
+    let right_size = self.right.get_num_records();
 
-    let left_num_records: usize = self.left.get_num_records();
-    let right_num_records: usize = self.right.get_num_records();
+    // Since this is a primary-key foreign-key equijoin
+    // we know the the join will be no larger than left table
+    let mut join_result = Vec::with_capacity(left_size);
 
-    for _l in 0..left_num_records {
-      let mut left_record: Record = self.left.read_next_record().clone();
+    for _l in 0..left_size {
+      let left_record = self.left.read_next_record();
 
-      for _r in 0..right_num_records {
-        let mut right_record: Record = self.right.read_next_record();
+      for _r in 0..right_size {
+        let right_record = self.right.read_next_record();
 
         if left_record.get_column(left_col) == right_record.get_column(right_col) {
           // Join condition is met ==> new record 
-          let join_record: Record = Record::merge(&mut left_record, &mut right_record);
+          let join_record = Record::merge(left_record, right_record);
           join_result.push(join_record);
         }
       }
       self.right.rewind();
     }
     self.left.rewind();
+
     join_result
   }
 }
@@ -73,24 +76,36 @@ impl<'a> BlockNL<'a> {
     }
   }
 
+  fn get_effective_block_size(&self, num_records: usize, block_size: usize) -> usize {
+    let intermidate: f64 = ((num_records as f64) / (block_size as f64)).ceil();
+    intermidate as usize
+  }
+
   pub fn equi_join(&mut self, left_col: usize, right_col: usize) -> Vec<Record> {
-    // TODO: Remove the duplicated concatenation
-    let mut join_result: Vec<Record> = Vec::new();
+    // Number of records in left and right tables
+    let left_size = self.left.get_num_records();
+    let right_size = self.right.get_num_records();
 
-    let left_num_blocks: f64 = ((self.left.get_num_records() as f64) / (self.l_block_sz as f64)).ceil();
-    let right_num_blocks: f64 = ((self.right.get_num_records() as f64) / (self.r_block_sz as f64)).ceil();
+    // Number of effective blocks for left and right tables
+    let effective_l_block_sz = self.get_effective_block_size(left_size, self.l_block_sz);
+    let effective_r_block_sz = self.get_effective_block_size(right_size, self.r_block_sz);
 
-    for _l in 0..(left_num_blocks as usize) {
+    // Since this is a primary-key foreign-key equijoin
+    // we know the the join will be no larger than left table
+    let mut join_result = Vec::with_capacity(left_size);
+
+    for _l in 0..effective_l_block_sz  {
       let left_block = self.left.read_next_block(self.l_block_sz);
 
-      for _r in 0..(right_num_blocks as usize){
+      for _r in 0..effective_r_block_sz {
         let right_block = self.right.read_next_block(self.r_block_sz);
 
-        for mut left_record in left_block {
-          for mut right_record in right_block {
+        for left_record in left_block {
+          for right_record in right_block {
+
             if left_record.get_column(left_col) == right_record.get_column(right_col) {
               // Join condition is met ==> new record 
-              let join_record: Record = Record::merge(&mut left_record, &mut right_record);
+              let join_record = Record::merge(left_record, right_record);
               join_result.push(join_record);
             }
           }
@@ -99,6 +114,7 @@ impl<'a> BlockNL<'a> {
       self.right.rewind();
     }
     self.left.rewind();
+
     join_result
   }
 
@@ -126,31 +142,51 @@ impl<'a> SimpleHashJoin<'a> {
   }
 
   pub fn equi_join(&mut self, left_col: usize, right_col: usize) -> Vec<Record> {
-    // TODO: Remove the duplicated concatenation
-    let mut join_result: Vec<Record> = Vec::new();
-    let mut hashtable: HashMap<i32, Vec<Record>> = HashMap::new();
+    // Number of records in left and right tables
+    let left_size = self.left.get_num_records();
+    let right_size = self.right.get_num_records();
 
-    let left_num_records: usize = self.left.get_num_records();
-    let right_num_records: usize = self.right.get_num_records();
+    // Since this is a primary-key foreign-key equijoin
+    // we know the the join will be no larger than left table
+    let mut join_result = Vec::with_capacity(left_size);
 
-    for _l in 0..right_num_records {
-      let right_record: Record = self.right.read_next_record().clone();
-      hashtable.entry(right_record.get_column(right_col)).or_insert(Vec::new()).push(right_record);
+    let mut hash_table: HashMap<&i32, Vec<&Record>> = HashMap::new();
+
+    // Get the right table's view of its records
+    let right_records = self.right.record_view();
+    assert!(right_size == right_records.len());
+
+    // Now we build the hash table on the smaller table
+    // since this results in the fewest operations during join
+    for r in right_records {
+      let right_column_value = r.get_column(right_col);
+
+      // Insert map from the hash of right join column value the record itself
+      hash_table.entry(right_column_value).or_insert(Vec::new()).push(r);
     }
-    self.right.rewind();
 
-    for _r in 0..left_num_records {
-      let mut left_record: Record = self.left.read_next_record().clone();
-      let matches = match hashtable.get(&left_record.get_column(left_col)) {
+    for _l in 0..left_size {
+      let left_record = self.left.read_next_record();
+      let left_column_value = left_record.get_column(left_col);
+      
+      match hash_table.get(left_column_value) {
+        // If hash table doesn't have this value, 
+        // we know for sure that this record does not 
+        // participate in the join
         None => continue,
-        Some(v) => v
+
+        // But if there are some matches for the value,
+        // then we know they ALL participate in the join
+        Some(right_record_matches) => {
+          for right_record in right_record_matches {
+            let join_record: Record = Record::merge(left_record, right_record);
+            join_result.push(join_record);
+          }
+        }
       };
-      for record in matches {
-        let join_record: Record = Record::merge(&mut left_record, &mut record.clone());
-          join_result.push(join_record);
-      }
     }
     self.left.rewind();
+
     join_result
   }
 }


### PR DESCRIPTION
The goal is to move away from cloning, as much as possible. Where necessary, we only want to clone `i32` fields. To achieve this, some redesign/reimplementation needed to happen:

* `Record` optimized to avoid `Vec` and instead use slices. Now exposes column values via a `&i32` so we don't copy
* `tablegenerator` needed to adapt to this change of interface
* `SimpleTable` needed to adapt also, but it also got similar optimization as `Record`
* `join` had the most interesting changes, now has no need for cloning values except in the hash table. And even then it's just cloning `i32`s!